### PR TITLE
Multivalued scoring

### DIFF
--- a/PermutationImportance/__init__.py
+++ b/PermutationImportance/__init__.py
@@ -11,4 +11,4 @@ from .sequential_selection import *
 from .result import ImportanceResult
 from . import sklearn_api
 
-__version__ = '1.2.0.5'
+__version__ = '1.2.1.0'

--- a/PermutationImportance/abstract_runner.py
+++ b/PermutationImportance/abstract_runner.py
@@ -20,10 +20,10 @@ def abstract_variable_importance(training_data, scoring_data, scoring_fn, scorin
     :param scoring_data: a 2-tuple (inputs, outputs) for scoring in the
         scoring_fn
     :param scoring_fn: a function to be used for scoring. Should be of the form
-        (training_data, scoring_data) -> float
+        (training_data, scoring_data) -> some value
     :param scoring_strategy: a function to be used for determining optimal
         variables or a string. If a function, should be of the form
-            ([floats]) -> index. If a string, must be one of the options in
+            ([some value]) -> index. If a string, must be one of the options in
         scoring_strategies.VALID_SCORING_STRATEGIES
     :param selection_strategy: an object which, when iterated, produces triples
         (var, training_data, scoring_data). Almost certainly a SelectionStrategy

--- a/PermutationImportance/data_verification.py
+++ b/PermutationImportance/data_verification.py
@@ -69,7 +69,7 @@ def determine_variable_names(data, variable_names):
                 raise InvalidInputException(
                     variable_names, "Variable names should have length %i" % data[0].shape[1])
             else:
-                return variable_names
+                return np.array(variable_names)
     else:
         if isinstance(data[0], pd.DataFrame):
             return data[0].columns.values

--- a/PermutationImportance/permutation_importance.py
+++ b/PermutationImportance/permutation_importance.py
@@ -18,10 +18,10 @@ def permutation_importance(scoring_data, scoring_fn, scoring_strategy, variable_
     :param scoring_data: a 2-tuple(inputs, outputs) for scoring in the
         scoring_fn
     :param scoring_fn: a function to be used for scoring. Should be of the form
-        (training_data, scoring_data) -> float, but should only use the 
+        (training_data, scoring_data) -> some_value, but should only use the 
         scoring_data to produce a score
     :param scoring_strategy: a function to be used for determining optimal
-        variables. Should be of the form([floats]) -> index
+        variables. Should be of the form([some_value]) -> index
     :param variable_names: an optional list for variable names. If not given,
         will use names of columns of data(if pandas dataframe) or column
         indices
@@ -35,7 +35,7 @@ def permutation_importance(scoring_data, scoring_fn, scoring_strategy, variable_
     return abstract_variable_importance((np.array([]), np.array([])), scoring_data, scoring_fn, scoring_strategy, PermutationImportanceSelectionStrategy, variable_names=variable_names, nimportant_vars=nimportant_vars, njobs=njobs)
 
 
-def sklearn_permutation_importance(model, scoring_data, evaluation_fn, scoring_strategy, variable_names=None, nimportant_vars=None, njobs=1, nbootstrap=1, subsample=1):
+def sklearn_permutation_importance(model, scoring_data, evaluation_fn, scoring_strategy, variable_names=None, nimportant_vars=None, njobs=1, nbootstrap=1, subsample=1, **kwargs):
     """Performs permutation importance for a particular model, 
     scoring_data, evaluation_fn, and strategy for determining optimal variables
 
@@ -44,10 +44,10 @@ def sklearn_permutation_importance(model, scoring_data, evaluation_fn, scoring_s
         scoring_fn
     :param evaluation_fn: a function which takes the deterministic or 
         probabilistic model predictions and scores them against the true 
-        values. Must be of the form (truths, predictions) -> float
+        values. Must be of the form (truths, predictions) -> some_value
         Probably one of the metrics in PermutationImportance.metrics or sklearn.metrics
     :param scoring_strategy: a function to be used for determining optimal
-        variables. Should be of the form([floats]) -> index
+        variables. Should be of the form([some_value]) -> index
     :param variable_names: an optional list for variable names. If not given,
         will use names of columns of data(if pandas dataframe) or column
         indices
@@ -62,13 +62,14 @@ def sklearn_permutation_importance(model, scoring_data, evaluation_fn, scoring_s
         of total number of events (e.g. 0.5 means half the number of events).
         If not specified, subsampling will not be used and the entire data will
         be used (without replacement)
+    :param kwargs: all other kwargs will be passed on to the evaluation_fn
     :returns: ImportanceResult object which contains the results for each run
     """
     # Check if the data is probabilistic
     if len(scoring_data[1].shape) > 1 and scoring_data[1].shape[1] > 1:
         scoring_fn = score_trained_sklearn_model_with_probabilities(
-            model, evaluation_fn, nbootstrap=nbootstrap, subsample=subsample)
+            model, evaluation_fn, nbootstrap=nbootstrap, subsample=subsample, **kwargs)
     else:
         scoring_fn = score_trained_sklearn_model(
-            model, evaluation_fn, nbootstrap=nbootstrap, subsample=subsample)
+            model, evaluation_fn, nbootstrap=nbootstrap, subsample=subsample, **kwargs)
     return permutation_importance(scoring_data, scoring_fn, scoring_strategy, variable_names=variable_names, nimportant_vars=nimportant_vars, njobs=njobs)

--- a/PermutationImportance/scoring_strategies.py
+++ b/PermutationImportance/scoring_strategies.py
@@ -6,17 +6,8 @@ import numpy as np
 
 from .error_handling import InvalidStrategyException
 
-__all__ = ["verify_scoring_strategy", "VALID_SCORING_STRATEGIES"]
-
-
-VALID_SCORING_STRATEGIES = {
-    'max': np.argmax,
-    'maximize': np.argmax,
-    'argmax': np.argmax,
-    'min': np.argmin,
-    'minimize': np.argmin,
-    'argmin': np.argmin,
-}
+__all__ = ["verify_scoring_strategy", "VALID_SCORING_STRATEGIES",
+           "argmin_of_mean", "argmax_of_mean"]
 
 
 def verify_scoring_strategy(scoring_strategy):
@@ -35,3 +26,23 @@ def verify_scoring_strategy(scoring_strategy):
     else:
         raise InvalidStrategyException(
             scoring_strategy, options=VALID_SCORING_STRATEGIES.keys())
+
+
+def argmin_of_mean(scores):
+    return np.argmin(np.mean(scores))
+
+
+def argmax_of_mean(scores):
+    return np.argmin(np.mean(scores))
+
+
+VALID_SCORING_STRATEGIES = {
+    'max': np.argmax,
+    'maximize': np.argmax,
+    'argmax': np.argmax,
+    'min': np.argmin,
+    'minimize': np.argmin,
+    'argmin': np.argmin,
+    'argmin_of_mean': argmin_of_mean,
+    'argmax_of_mean': argmax_of_mean,
+}

--- a/PermutationImportance/sequential_selection.py
+++ b/PermutationImportance/sequential_selection.py
@@ -35,7 +35,7 @@ def sequential_forward_selection(training_data, scoring_data, scoring_fn, scorin
     return abstract_variable_importance(training_data, scoring_data, scoring_fn, scoring_strategy, SequentialForwardSelectionStrategy, variable_names=variable_names, nimportant_vars=nimportant_vars, njobs=njobs)
 
 
-def sklearn_sequential_forward_selection(model, training_data, scoring_data, evaluation_fn, scoring_strategy, variable_names=None, nimportant_vars=None, njobs=1, nbootstrap=1, subsample=1):
+def sklearn_sequential_forward_selection(model, training_data, scoring_data, evaluation_fn, scoring_strategy, variable_names=None, nimportant_vars=None, njobs=1, nbootstrap=None, subsample=1, **kwargs):
     """Performs sequential forward selection for a particular model, 
     scoring_data, evaluation_fn, and strategy for determining optimal variables
 
@@ -46,10 +46,10 @@ def sklearn_sequential_forward_selection(model, training_data, scoring_data, eva
         scoring_fn
     :param evaluation_fn: a function which takes the deterministic or 
         probabilistic model predictions and scores them against the true 
-        values. Must be of the form (truths, predictions) -> float
-        Probably one of the metrics in .metrics or sklearn.metrics
+        values. Must be of the form (truths, predictions) -> some_value
+        Probably one of the metrics in PermutationImportance.metrics or sklearn.metrics
     :param scoring_strategy: a function to be used for determining optimal
-        variables. Should be of the form([floats]) -> index
+        variables. Should be of the form([some_value]) -> index
     :param variable_names: an optional list for variable names. If not given,
         will use names of columns of data(if pandas dataframe) or column
         indices
@@ -64,15 +64,16 @@ def sklearn_sequential_forward_selection(model, training_data, scoring_data, eva
         of total number of events (e.g. 0.5 means half the number of events).
         If not specified, subsampling will not be used and the entire data will
         be used (without replacement)
+    :param kwargs: all other kwargs will be passed on to the evaluation_fn
     :returns: ImportanceResult object which contains the results for each run
     """
     # Check if the data is probabilistic
     if len(scoring_data[1].shape) > 1 and scoring_data[1].shape[1] > 1:
         scoring_fn = score_untrained_sklearn_model_with_probabilities(
-            model, evaluation_fn, nbootstrap=nbootstrap, subsample=subsample)
+            model, evaluation_fn, nbootstrap=nbootstrap, subsample=subsample, **kwargs)
     else:
         scoring_fn = score_untrained_sklearn_model(
-            model, evaluation_fn, nbootstrap=nbootstrap, subsample=subsample)
+            model, evaluation_fn, nbootstrap=nbootstrap, subsample=subsample, **kwargs)
     return sequential_forward_selection(training_data, scoring_data, scoring_fn, scoring_strategy, variable_names=variable_names, nimportant_vars=nimportant_vars, njobs=njobs)
 
 
@@ -100,7 +101,7 @@ def sequential_backward_selection(training_data, scoring_data, scoring_fn, scori
     return abstract_variable_importance(training_data, scoring_data, scoring_fn, scoring_strategy, SequentialBackwardSelectionStrategy, variable_names=variable_names, nimportant_vars=nimportant_vars, njobs=njobs)
 
 
-def sklearn_sequential_backward_selection(model, training_data, scoring_data, evaluation_fn, scoring_strategy, variable_names=None, nimportant_vars=None, njobs=1, nbootstrap=1, subsample=1):
+def sklearn_sequential_backward_selection(model, training_data, scoring_data, evaluation_fn, scoring_strategy, variable_names=None, nimportant_vars=None, njobs=1, nbootstrap=None, subsample=1, **kwargs):
     """Performs sequential backward selection for a particular model, 
     scoring_data, evaluation_fn, and strategy for determining optimal variables
 
@@ -111,10 +112,10 @@ def sklearn_sequential_backward_selection(model, training_data, scoring_data, ev
         scoring_fn
     :param evaluation_fn: a function which takes the deterministic or 
         probabilistic model predictions and scores them against the true 
-        values. Must be of the form (truths, predictions) -> float
-        Probably one of the metrics in .metrics or sklearn.metrics
+        values. Must be of the form (truths, predictions) -> some_value
+        Probably one of the metrics in PermutationImportance.metrics or sklearn.metrics
     :param scoring_strategy: a function to be used for determining optimal
-        variables. Should be of the form([floats]) -> index
+        variables. Should be of the form([some_value]) -> index
     :param variable_names: an optional list for variable names. If not given,
         will use names of columns of data(if pandas dataframe) or column
         indices
@@ -129,13 +130,14 @@ def sklearn_sequential_backward_selection(model, training_data, scoring_data, ev
         of total number of events (e.g. 0.5 means half the number of events).
         If not specified, subsampling will not be used and the entire data will
         be used (without replacement)
+    :param kwargs: all other kwargs will be passed on to the evaluation_fn
     :returns: ImportanceResult object which contains the results for each run
     """
     # Check if the data is probabilistic
     if len(scoring_data[1].shape) > 1 and scoring_data[1].shape[1] > 1:
         scoring_fn = score_untrained_sklearn_model_with_probabilities(
-            model, evaluation_fn, nbootstrap=nbootstrap, subsample=subsample)
+            model, evaluation_fn, nbootstrap=nbootstrap, subsample=subsample, **kwargs)
     else:
         scoring_fn = score_untrained_sklearn_model(
-            model, evaluation_fn, nbootstrap=nbootstrap, subsample=subsample)
+            model, evaluation_fn, nbootstrap=nbootstrap, subsample=subsample, **kwargs)
     return sequential_backward_selection(training_data, scoring_data, scoring_fn, scoring_strategy, variable_names=variable_names, nimportant_vars=nimportant_vars, njobs=njobs)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ CLASSIFIERS = [
 PACKAGE_REQUIREMENTS = ['numpy', 'pandas', 'scipy==1.1.0', 'sklearn']
 
 if __name__ == '__main__':
-    setup(name='PermutationImportance', version='1.2.0.5',
+    setup(name='PermutationImportance', version='1.2.1.0',
           description=SHORT_DESCRIPTION,
           author='G. Eli Jergensen', author_email='gelijergensen@ou.edu',
           long_description=long_description,

--- a/test/test_sklearn_api.py
+++ b/test/test_sklearn_api.py
@@ -48,8 +48,8 @@ def test_model_scorer():
 
     score = score_fn(training_data, scoring_data)
 
-    assert 0 <= score
-    assert score <= 1
+    assert (0 <= score).all()
+    assert (score <= 1).all()
 
     score_fn = model_scorer(model, train_model, predict_model,
                             accuracy_score, nbootstrap=5, subsample=0.2)
@@ -58,8 +58,8 @@ def test_model_scorer():
 
     score = score_fn(training_data, scoring_data)
 
-    assert 0 <= score
-    assert score <= 1
+    assert (0 <= score).all()
+    assert (score <= 1).all()
 
 
 def test_score_sklearn_models():


### PR DESCRIPTION
Scoring functions can now return any object that they would like, so long as the `scoring_strategy` function is equipped to handle it.

Added some additional `scoring_strategy` functions to handle arrays of floats.

Fixed bootstrapping in the `sklearn_api` to properly bootstrap only over the scoring, not the predicting.

Also fixed variable names to be numpy arrays under the hood

resolves #65 
resolves #63 
resolves #62 